### PR TITLE
Updated Membrane to depend on MetaModel 5.0-RC4

### DIFF
--- a/core/src/main/java/org/apache/metamodel/membrane/controllers/DataSourceController.java
+++ b/core/src/main/java/org/apache/metamodel/membrane/controllers/DataSourceController.java
@@ -18,7 +18,6 @@
  */
 package org.apache.metamodel.membrane.controllers;
 
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -89,7 +88,7 @@ public class DataSourceController {
         final String tenantName = tenantContext.getTenantName();
         final UriBuilder uriBuilder = UriBuilder.fromPath("/{tenant}/{dataContext}/s/{schema}");
 
-        final List<GetDatasourceResponseSchemas> schemaLinks = Arrays.stream(dataContext.getSchemaNames()).map(s -> {
+        final List<GetDatasourceResponseSchemas> schemaLinks = dataContext.getSchemaNames().stream().map(s -> {
             final String uri = uriBuilder.build(tenantName, dataSourceName, s).toString();
             return new GetDatasourceResponseSchemas().name(s).uri(uri);
         }).collect(Collectors.toList());

--- a/core/src/main/java/org/apache/metamodel/membrane/controllers/QueryController.java
+++ b/core/src/main/java/org/apache/metamodel/membrane/controllers/QueryController.java
@@ -78,7 +78,7 @@ public class QueryController {
         final List<List<Object>> data = new ArrayList<>();
 
         try (final DataSet dataSet = dataContext.executeQuery(query)) {
-            headers = Arrays.stream(dataSet.getSelectItems()).map((si) -> si.toString()).collect(Collectors.toList());
+            headers = dataSet.getSelectItems().stream().map((si) -> si.toString()).collect(Collectors.toList());
             while (dataSet.next()) {
                 final Object[] values = dataSet.getRow().getValues();
                 data.add(Arrays.asList(values));

--- a/core/src/main/java/org/apache/metamodel/membrane/controllers/SchemaController.java
+++ b/core/src/main/java/org/apache/metamodel/membrane/controllers/SchemaController.java
@@ -18,7 +18,6 @@
  */
 package org.apache.metamodel.membrane.controllers;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -65,7 +64,7 @@ public class SchemaController {
         final UriBuilder uriBuilder = UriBuilder.fromPath("/{tenant}/{dataContext}/s/{schema}/t/{table}");
 
         final String schemaName = schema.getName();
-        final List<GetSchemaResponseTables> tableLinks = Arrays.stream(schema.getTableNames()).map(t -> {
+        final List<GetSchemaResponseTables> tableLinks = schema.getTableNames().stream().map(t -> {
             final String uri = uriBuilder.build(tenantName, dataSourceName, schemaName, t).toString();
             return new GetSchemaResponseTables().name(String.valueOf(t)).uri(uri);
         }).collect(Collectors.toList());

--- a/core/src/main/java/org/apache/metamodel/membrane/controllers/TableController.java
+++ b/core/src/main/java/org/apache/metamodel/membrane/controllers/TableController.java
@@ -18,7 +18,6 @@
  */
 package org.apache.metamodel.membrane.controllers;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -68,7 +67,7 @@ public class TableController {
 
         final String tableName = table.getName();
         final String schemaName = table.getSchema().getName();
-        final List<GetTableResponseColumns> columnsLinks = Arrays.stream(table.getColumnNames()).map(c -> {
+        final List<GetTableResponseColumns> columnsLinks = table.getColumnNames().stream().map(c -> {
             final String uri = uriBuilder.build(tenantName, dataSourceName, schemaName, tableName, c).toString();
             return new GetTableResponseColumns().name(c).uri(uri);
         }).collect(Collectors.toList());

--- a/pom.xml
+++ b/pom.xml
@@ -21,12 +21,12 @@ under the License.
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<properties>
-		<metamodel.version>5.0-RC3</metamodel.version>
+		<metamodel.version>5.0-RC4</metamodel.version>
 	</properties>
 	<parent>
 		<groupId>org.apache.metamodel</groupId>
 		<artifactId>MetaModel</artifactId>
-		<version>5.0-RC3</version>
+		<version>5.0-RC4</version>
 	</parent>
 	<scm>
 		<url>https://git-wip-us.apache.org/repos/asf?p=metamodel-membrane.git</url>


### PR DESCRIPTION
This PR updates the MM dependency to the just-released version 5.0-RC4.

APIs updated to use the collections instead of arrays accordingly (following https://github.com/apache/metamodel/pull/153).

A lot more DataContextFactories are now available too, making Membrane generally more capable (following https://github.com/apache/metamodel/pull/155).