### PR TITLE
METAMODEL-1150: Docker build (and a bit more)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,12 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-FROM openjdk:8-jre-alpine
-
-COPY target/membrane-undertow-server.jar membrane-undertow-server.jar
-
-VOLUME /data
-
-ENV DATA_DIRECTORY=/data
-
-CMD java -server -jar membrane-undertow-server.jar
+**/target

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+FROM maven:3.5-jdk-8-alpine
+
+# Set data directory used for the app's persistence
+VOLUME /data
+ENV DATA_DIRECTORY=/data
+
+COPY . /usr/src/app
+WORKDIR /usr/src/app
+
+RUN mvn clean install -Pdockerbuild -DskipTests
+
+CMD java -server -jar undertow/target/membrane-undertow-server.jar

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -86,6 +86,18 @@ under the License.
 			<groupId>org.slf4j</groupId>
 			<artifactId>jcl-over-slf4j</artifactId>
 		</dependency>
+		
+		<!-- Database drivers -->
+		<dependency>
+			<groupId>org.postgresql</groupId>
+			<artifactId>postgresql</artifactId>
+			<version>42.1.4</version>
+		</dependency>
+		<dependency>
+			<groupId>net.sourceforge.jtds</groupId>
+			<artifactId>jtds</artifactId>
+			<version>1.3.1</version>
+		</dependency>
 
 		<!-- Provided -->
 		<dependency>

--- a/core/src/main/java/org/apache/metamodel/membrane/controllers/DataSourceController.java
+++ b/core/src/main/java/org/apache/metamodel/membrane/controllers/DataSourceController.java
@@ -65,11 +65,6 @@ public class DataSourceController {
         map.putAll(dataContextDefinition.getProperties());
         map.put(DataContextPropertiesImpl.PROPERTY_DATA_CONTEXT_TYPE, dataContextDefinition.getType());
 
-        if (!map.containsKey(DataContextPropertiesImpl.PROPERTY_DATABASE)) {
-            // add the data source ID as database name if it is not already set.
-            map.put(DataContextPropertiesImpl.PROPERTY_DATABASE, dataSourceId);
-        }
-
         final DataContextProperties properties = new DataContextPropertiesImpl(map);
 
         final String dataContextIdentifier = tenantRegistry.getTenantContext(tenantId).getDataSourceRegistry()

--- a/core/src/test/java/org/apache/metamodel/membrane/controllers/TenantInteractionScenarioTest.java
+++ b/core/src/test/java/org/apache/metamodel/membrane/controllers/TenantInteractionScenarioTest.java
@@ -77,7 +77,7 @@ public class TenantInteractionScenarioTest {
         // create datasource
         {
             final MvcResult result = mockMvc.perform(MockMvcRequestBuilders.put("/tenant1/mydata").content(
-                    "{'type':'pojo','table-defs':'hello_world (greeting VARCHAR, who VARCHAR); foo (bar INTEGER, baz DATE);'}"
+                    "{'type':'pojo','database':'mydata','table-defs':'hello_world (greeting VARCHAR, who VARCHAR); foo (bar INTEGER, baz DATE);'}"
                             .replace('\'', '"')).contentType(MediaType.APPLICATION_JSON)).andExpect(
                                     MockMvcResultMatchers.status().isOk()).andReturn();
 
@@ -185,8 +185,8 @@ public class TenantInteractionScenarioTest {
         // query metadata from information_schema
         {
             final MvcResult result = mockMvc.perform(MockMvcRequestBuilders.get("/tenant1/mydata/q?sql={sql}",
-                    "SELECT greeting, who AS who_is_it FROM hello_world")).andExpect(MockMvcResultMatchers.status()
-                            .isOk()).andReturn();
+                    "SELECT greeting, who AS who_is_it FROM hello_world"))
+                    .andExpect(MockMvcResultMatchers.status().isOk()).andReturn();
 
             final String content = result.getResponse().getContentAsString();
             final Map<?, ?> map = new ObjectMapper().readValue(content, Map.class);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,8 +19,23 @@ services:
   metamodel-membrane:
     container_name: metamodel-membrane
     image: metamodel-membrane
-    build: undertow
+    build: .
     ports:
     - "8080:8080"
     environment:
     - MEMBRANE_HTTP_PORT=8080
+  example-postgres:
+    container_name: example-postgres
+    image: postgres:9.6
+    environment:
+    - POSTGRES_USER=membrane
+    - POSTGRES_PASSWORD=secret
+    - POSTGRES_DB=membrane
+  example-couchdb:
+    container_name: example-couchdb
+    image: couchdb:1.6
+    environment:
+    - COUCHDB_USER=membrane
+    - COUCHDB_PASSWORD=secret
+    ports:
+    - 5984:5984

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@ under the License.
 	<url>http://metamodel.apache.org</url>
 	<inceptionYear>2017</inceptionYear>
 	<packaging>pom</packaging>
-	
+
 	<profiles>
 		<profile>
 			<id>all</id>
@@ -65,6 +65,51 @@ under the License.
 			</modules>
 		</profile>
 	</profiles>
+
+	<build>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>org.apache.rat</groupId>
+					<artifactId>apache-rat-plugin</artifactId>
+					<configuration>
+						<licenses>
+							<license
+								implementation="org.apache.rat.analysis.license.SimplePatternBasedLicense">
+								<licenseFamilyCategory>ASL20</licenseFamilyCategory>
+								<licenseFamilyName>Apache Software License, 2.0</licenseFamilyName>
+								<notes>Single licensed ASL v2.0</notes>
+								<patterns>
+									<pattern>Licensed to the Apache Software Foundation (ASF) under
+										one
+										or more contributor license agreements.</pattern>
+								</patterns>
+							</license>
+						</licenses>
+						<excludeSubProjects>false</excludeSubProjects>
+						<excludes>
+							<exclude>KEYS</exclude>
+							<exclude>**/*.md</exclude>
+							<exclude>**/*.json</exclude>
+							<exclude>**/.gitignore/**</exclude>
+							<exclude>.git/**</exclude>
+							<exclude>.gitattributes</exclude>
+							<exclude>**/.project</exclude>
+							<exclude>**/.classpath</exclude>
+							<exclude>**/.settings/**</exclude>
+							<exclude>**/.vscode/**</exclude>
+							<exclude>**/.travis.yml</exclude>
+							<exclude>**/target/**</exclude>
+							<exclude>**/*.iml/**</exclude>
+							<exclude>**/*.iws/**</exclude>
+							<exclude>**/*.ipr/**</exclude>
+							<exclude>**/.idea/**</exclude>
+						</excludes>
+					</configuration>
+				</plugin>
+			</plugins>
+		</pluginManagement>
+	</build>
 
 	<dependencyManagement>
 		<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -42,12 +42,29 @@ under the License.
 	<url>http://metamodel.apache.org</url>
 	<inceptionYear>2017</inceptionYear>
 	<packaging>pom</packaging>
-	<modules>
-		<module>swagger-codegen</module>
-		<module>core</module>
-		<module>war</module>
-		<module>undertow</module>
-	</modules>
+	
+	<profiles>
+		<profile>
+			<id>all</id>
+			<activation>
+				<activeByDefault>true</activeByDefault>
+			</activation>
+			<modules>
+				<module>swagger-codegen</module>
+				<module>core</module>
+				<module>war</module>
+				<module>undertow</module>
+			</modules>
+		</profile>
+		<profile>
+			<id>dockerbuild</id>
+			<modules>
+				<module>swagger-codegen</module>
+				<module>core</module>
+				<module>undertow</module>
+			</modules>
+		</profile>
+	</profiles>
 
 	<dependencyManagement>
 		<dependencies>

--- a/postman-tests/Membrane.postman_collection.json
+++ b/postman-tests/Membrane.postman_collection.json
@@ -1,0 +1,202 @@
+{
+	"variables": [],
+	"info": {
+		"name": "Membrane",
+		"_postman_id": "084c91ce-fccc-8fc4-a3c4-1dc5d5b41388",
+		"description": "",
+		"schema": "https://schema.getpostman.com/json/collection/v2.0.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "Create my-tenant",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"type": "text/javascript",
+						"exec": [
+							"tests[\"Status code is 200\"] = responseCode.code === 200;",
+							"",
+							"var jsonData = JSON.parse(responseBody);",
+							"tests[\"type is tenant\"] = jsonData.type === \"tenant\";"
+						]
+					}
+				}
+			],
+			"request": {
+				"url": "{{baseUrl}}/my-tenant",
+				"method": "PUT",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json",
+						"description": ""
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \n}"
+				},
+				"description": ""
+			},
+			"response": []
+		},
+		{
+			"name": "Get my-tenant",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"type": "text/javascript",
+						"exec": [
+							"tests[\"Status code is 200\"] = responseCode.code === 200;",
+							"",
+							"var jsonData = JSON.parse(responseBody);",
+							"tests[\"type is tenant\"] = jsonData.type === \"tenant\";"
+						]
+					}
+				}
+			],
+			"request": {
+				"url": "{{baseUrl}}/my-tenant",
+				"method": "GET",
+				"header": [],
+				"body": {},
+				"description": ""
+			},
+			"response": []
+		},
+		{
+			"name": "Create my-tenant/example-pojo",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"type": "text/javascript",
+						"exec": [
+							"tests[\"Status code is 200\"] = responseCode.code === 200;",
+							"",
+							"var jsonData = JSON.parse(responseBody);",
+							"tests[\"type is datasource\"] = jsonData.type === \"datasource\";",
+							"tests[\"is updateable\"] = jsonData.updateable;"
+						]
+					}
+				}
+			],
+			"request": {
+				"url": "{{baseUrl}}/my-tenant/example-pojo",
+				"method": "PUT",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json",
+						"description": ""
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"type\":\"pojo\",\n    \"table-defs\":\"hello_world (greeting VARCHAR, who VARCHAR); foo (bar INTEGER, baz DATE);\"\n}"
+				},
+				"description": ""
+			},
+			"response": []
+		},
+		{
+			"name": "Create my-tenant/example-postgres",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"type": "text/javascript",
+						"exec": [
+							"tests[\"Status code is 200\"] = responseCode.code === 200;",
+							"",
+							"var jsonData = JSON.parse(responseBody);",
+							"tests[\"type is datasource\"] = jsonData.type === \"datasource\";",
+							"tests[\"is updateable\"] = jsonData.updateable;"
+						]
+					}
+				}
+			],
+			"request": {
+				"url": "{{baseUrl}}/my-tenant/example-postgres",
+				"method": "PUT",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json",
+						"description": ""
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"type\":\"jdbc\",\n    \"url\": \"jdbc:postgresql://example-postgres/membrane\",\n    \"username\": \"membrane\",\n    \"password\": \"secret\"\n}"
+				},
+				"description": ""
+			},
+			"response": []
+		},
+		{
+			"name": "Create my-tenant/example-couchdb",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"type": "text/javascript",
+						"exec": [
+							"tests[\"Status code is 200\"] = responseCode.code === 200;",
+							"",
+							"var jsonData = JSON.parse(responseBody);",
+							"tests[\"type is datasource\"] = jsonData.type === \"datasource\";",
+							"tests[\"is updateable\"] = jsonData.updateable;"
+						]
+					}
+				}
+			],
+			"request": {
+				"url": "{{baseUrl}}/my-tenant/example-couchdb",
+				"method": "PUT",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json",
+						"description": ""
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"type\":\"couchdb\",\n    \"hostname\": \"example-couchdb\",\n    \"username\": \"membrane\",\n    \"password\": \"secret\"\n}"
+				},
+				"description": ""
+			},
+			"response": []
+		},
+		{
+			"name": "Delete my-tenant",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"type": "text/javascript",
+						"exec": [
+							"tests[\"Status code is 200\"] = responseCode.code === 200;",
+							"",
+							"var jsonData = JSON.parse(responseBody);",
+							"tests[\"type is tenant\"] = jsonData.type === \"tenant\";",
+							"tests[\"deleted is true\"] = jsonData.deleted;",
+							""
+						]
+					}
+				}
+			],
+			"request": {
+				"url": "{{baseUrl}}/my-tenant",
+				"method": "DELETE",
+				"header": [],
+				"body": {},
+				"description": ""
+			},
+			"response": []
+		}
+	]
+}

--- a/postman-tests/README.md
+++ b/postman-tests/README.md
@@ -1,0 +1,20 @@
+# Membrane Postman tests
+
+This folder has a set of tests and examples for use with the [Postman](https://www.getpostman.com/) tool.
+
+## Environment files
+
+The environments folder contains a set of reusable environment configs. Creating your own custom environment file should also be trivial since we only currently have one environment variable: `baseUrl`. 
+
+## Prerequisites
+
+The tests are designed to work with the default `docker-compose.yml` file in the root of the membrane project. This compose file has some databases and such which are used as part of the tests.
+
+## Running from command line
+
+If you have Postman's CLI tool `newman` installed, simply go like this:
+
+```
+newman run -e environments/docker-toolbox.postman_environment.json Membrane.postman_collection.json
+```
+(using the `docker-toolbox` environment)

--- a/postman-tests/environments/docker-toolbox.postman_environment.json
+++ b/postman-tests/environments/docker-toolbox.postman_environment.json
@@ -1,6 +1,6 @@
 {
   "id": "556c1331-5e87-4201-2767-8089cdb8e523",
-  "name": "Membrane boot2docker",
+  "name": "Membrane docker-toolbox",
   "values": [
     {
       "enabled": true,

--- a/postman-tests/environments/docker-toolbox.postman_environment.json
+++ b/postman-tests/environments/docker-toolbox.postman_environment.json
@@ -1,0 +1,16 @@
+{
+  "id": "556c1331-5e87-4201-2767-8089cdb8e523",
+  "name": "Membrane boot2docker",
+  "values": [
+    {
+      "enabled": true,
+      "key": "baseUrl",
+      "value": "http://192.168.99.100:8080",
+      "type": "text"
+    }
+  ],
+  "timestamp": 1503214232219,
+  "_postman_variable_scope": "environment",
+  "_postman_exported_at": "2017-08-20T08:06:07.385Z",
+  "_postman_exported_using": "Postman/5.1.3"
+}

--- a/postman-tests/environments/localhost.postman_environment.json
+++ b/postman-tests/environments/localhost.postman_environment.json
@@ -1,0 +1,16 @@
+{
+  "id": "fa99af7e-2115-254e-649e-7a2742704dbb",
+  "name": "Membrane local",
+  "values": [
+    {
+      "enabled": true,
+      "key": "baseUrl",
+      "value": "http://localhost:8080",
+      "type": "text"
+    }
+  ],
+  "timestamp": 1503066492942,
+  "_postman_variable_scope": "environment",
+  "_postman_exported_at": "2017-08-20T08:06:12.977Z",
+  "_postman_exported_using": "Postman/5.1.3"
+}

--- a/postman-tests/environments/localhost.postman_environment.json
+++ b/postman-tests/environments/localhost.postman_environment.json
@@ -1,6 +1,6 @@
 {
   "id": "fa99af7e-2115-254e-649e-7a2742704dbb",
-  "name": "Membrane local",
+  "name": "Membrane localhost",
   "values": [
     {
       "enabled": true,


### PR DESCRIPTION
I have been working on this PR to fix METAMODEL-1150. DockerHub will be doing builds like this only (without any maven pre-packaging steps):
```
docker build -t metamodel-membrane .
```
So the way the project is organized needed to support that. So with this PR, building the docker image now includes doing the maven build; a particular profile only which does not include all the tests and stuff. I figured that the tests would be better caught by Travis CI.

Now that the Docker build is working, I then started looking at integration tests. I built some using Postman and committed those too - I think they make a lot of sense and may also serve as examples for curious users.