### PR TITLE
Updated docker-compose image to official `apache/metamodel-membrane`.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ version: '2'
 services:
   metamodel-membrane:
     container_name: metamodel-membrane
-    image: metamodel-membrane
+    image: apache/metamodel-membrane
     build: .
     ports:
     - "8080:8080"


### PR DESCRIPTION
This will make it easier to release to docker hub. Simply run (given enough access rights):

```
docker-compose build
docker push apache/metamodel-membrane:[version]
```