### PR TITLE
Updated MetaModel dependency to v. 5.0 by using staged release repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,12 +21,12 @@ under the License.
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<properties>
-		<metamodel.version>5.0-RC4</metamodel.version>
+		<metamodel.version>5.0.0</metamodel.version>
 	</properties>
 	<parent>
 		<groupId>org.apache.metamodel</groupId>
 		<artifactId>MetaModel</artifactId>
-		<version>5.0-RC4</version>
+		<version>5.0.0</version>
 	</parent>
 	<scm>
 		<url>https://git-wip-us.apache.org/repos/asf?p=metamodel-membrane.git</url>
@@ -42,6 +42,16 @@ under the License.
 	<url>http://metamodel.apache.org</url>
 	<inceptionYear>2017</inceptionYear>
 	<packaging>pom</packaging>
+
+	<repositories>
+		<repository>
+			<id>metamodel-5-staging</id>
+			<url>http://repository.apache.org/content/repositories/orgapachemetamodel-1026</url>
+			<releases>
+				<enabled>true</enabled>
+			</releases>
+		</repository>
+	</repositories>
 
 	<profiles>
 		<profile>

--- a/pom.xml
+++ b/pom.xml
@@ -43,16 +43,6 @@ under the License.
 	<inceptionYear>2017</inceptionYear>
 	<packaging>pom</packaging>
 
-	<repositories>
-		<repository>
-			<id>metamodel-5-staging</id>
-			<url>http://repository.apache.org/content/repositories/orgapachemetamodel-1026</url>
-			<releases>
-				<enabled>true</enabled>
-			</releases>
-		</repository>
-	</repositories>
-
 	<profiles>
 		<profile>
 			<!-- Normal profile for a build on a machine without specific tools like Docker or Newman installed -->


### PR DESCRIPTION
... Eventually the custom `<repository>` needs to go away. But I wanted to make sure this upgrade will go smoothly by trying it out already while the release is being voted on.