### PR TITLE
Fix build (https issues with Travis packages and Newman tests failing)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
 - sudo apt-get -qq update
 - sudo apt-get install -y npm
 - sudo npm config set registry="http://registry.npmjs.org/"
-- sudo npm install newman@3.9.4 --global;
+- sudo npm install newman@3.9.3 --global;
 
 script:
 - mvn clean install -Pfull

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ services:
 - docker
 
 before_install:
+- curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
 - sudo apt-get -qq update
 - sudo apt-get install -y nodejs
 - sudo apt-get install -y npm

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ services:
 before_install:
 - sudo apt-get -qq update
 - sudo apt-get install npm
-- sudo npm install newman --global;
+- sudo npm install newman@3.9.4 --global;
 
 script:
 - mvn clean install -Pfull

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,9 @@ services:
 - docker
 
 before_install:
-- curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
 - sudo apt-get -qq update
-- sudo apt-get install -y nodejs
 - sudo apt-get install -y npm
+- sudo npm config set registry="http://registry.npmjs.org/"
 - sudo npm install newman@3.9.4 --global;
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ services:
 
 before_install:
 - sudo apt-get -qq update
-- sudo apt-get install npm
+- sudo apt-get install -y nodejs
+- sudo apt-get install -y npm
 - sudo npm install newman@3.9.4 --global;
 
 script:

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-FROM maven:3.5-jdk-8-alpine
+FROM maven:3-jdk-8
 
 # Set data directory used for the app's persistence
 VOLUME /data

--- a/postman-tests/pom.xml
+++ b/postman-tests/pom.xml
@@ -22,7 +22,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.metamodel.membrane</groupId>
 		<artifactId>Membrane-parent</artifactId>
-		<version>0.1-SNAPSHOT</version>
+		<version>0.2-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>Membrane-postman-tests</artifactId>

--- a/postman-tests/pom.xml
+++ b/postman-tests/pom.xml
@@ -111,6 +111,7 @@ under the License.
 							<![CDATA[
 			                -c "newman run ./Membrane.postman_collection.json \
 			                -e ./environments/${postman.env}.postman_environment.json \
+								 --disable-unicode \
 			                --reporters junit,cli -x \
 			                --reporter-junit-export ./target/NewmanTestResults.xml"
 			                ]]>


### PR DESCRIPTION
This is because newer versions of Newman (4.x) have a couple of changes to the test results XML which makes our current integration test "grep" check fail. Eventually we should get something better in place to check newman test results I think.