### PR TITLE
Add support for CORS

### DIFF
--- a/undertow/src/main/java/org/apache/metamodel/membrane/server/CorsHandlers.java
+++ b/undertow/src/main/java/org/apache/metamodel/membrane/server/CorsHandlers.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/undertow/src/main/java/org/apache/metamodel/membrane/server/CorsHandlers.java
+++ b/undertow/src/main/java/org/apache/metamodel/membrane/server/CorsHandlers.java
@@ -1,0 +1,28 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.metamodel.membrane.server;
+
+import io.undertow.server.HttpHandler;
+import io.undertow.server.handlers.SetHeaderHandler;
+
+public class CorsHandlers {
+    public HttpHandler allowOrigin(HttpHandler next) {
+        return new SetHeaderHandler(next, "Access-Control-Allow-Origin", "*");
+    }
+}

--- a/undertow/src/main/java/org/apache/metamodel/membrane/server/WebServer.java
+++ b/undertow/src/main/java/org/apache/metamodel/membrane/server/WebServer.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -53,7 +53,7 @@ public class WebServer {
 
         final String portEnv = System.getenv("MEMBRANE_HTTP_PORT");
         final int port = Strings.isNullOrEmpty(portEnv) ? DEFAULT_PORT : Integer.parseInt(portEnv);
-        final String enableCorsEnv = System.getenv("ENABLE_CORS");
+        final String enableCorsEnv = System.getenv("MEMBRANE_ENABLE_CORS");
         final boolean enableCors = !Strings.isNullOrEmpty(enableCorsEnv);
 
         logger.info("Apache MetaModel Membrane server initiating on port {}", port);
@@ -93,8 +93,9 @@ public class WebServer {
             CorsHandlers corsHandlers = new CorsHandlers();
             handler = corsHandlers.allowOrigin(manager.start());
         }
-        else
+        else {
             handler = manager.start();
+        }
 
         final Undertow server = Undertow.builder().addHttpListener(port, "0.0.0.0").setHandler(handler).build();
         server.start();


### PR DESCRIPTION
This PR is meant to make it easy to enable CORS (for instance, to support the use of an API visualisation tool or to call the server externally).

To run the updated server:

`$ ENABLE_CORS=true java -jar -server undertow/target/membrane-undertow-server.jar`

This is a very specific solution. If a more general solution is preferred (e.g. to support the addition of any kind of header), please feel free to modify it or to discard it altogether.